### PR TITLE
Add target to build DirectXTK shaders

### DIFF
--- a/DolphinSample.vcxproj
+++ b/DolphinSample.vcxproj
@@ -271,4 +271,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>
+  <Target Name="ATGEnsureShaders" BeforeTargets="PrepareForBuild">
+    <Exec Condition="!Exists('DirectXTK/src/Shaders/Compiled/SpriteEffect_SpriteVertexShader.inc')" WorkingDirectory="$(ProjectDir)DirectXTK/src/Shaders" Command="CompileShaders" />
+  </Target>
 </Project>


### PR DESCRIPTION
Because DirectXTK has been merged into the DolphinSample project, the special target for building DXTK shaders must be copied as well.